### PR TITLE
AWSカレントディレクトリにcompose.prod_fileを作成し、コンテナビルドに成功した

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { hsts: false }
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,16 +1,19 @@
 services:
   web:
-    build: .
+    image: ghcr.io/taka-thor/myapp:latest
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     env_file:
       - .env.production
     environment:
       RAILS_ENV: production
       TZ: Asia/Tokyo
+      RAILS_SERVE_STATIC_FILES: "true"
+      RAILS_LOG_TO_STDOUT: "true"
 
     ports:
       - "127.0.0.1:3000:3000"
-    #ホストIP : ホスト側ポート : コンテナ側ポート[Nginxの入り口(プロキシ)の場所：127.0.0.0.1に加えて、その入り口のポートを3000に指定(3000出なくてもOK)。このプロキシの場所とコンテナのPuma listening port3000をつなげている]
+    #ホストIP(127.0.0.1) : ホスト側ポート(3000) : コンテナ側ポート(3000)
+    #[Nginxの入り口(プロキシ)の場所：127.0.0.0.1に加えて、その入り口のポートを3000に指定(3000出なくてもOK)。このプロキシの場所とコンテナのPuma listening port3000をつなげている]
     volumes:
       - sqlite_data:/app/db
 


### PR DESCRIPTION
開発環境で使用したコンテナイメージをGHCRにあげ、AWSでプルして運用する方針

SECRET_KEY_BASEなどを記載した.env.productionファイルをprod.composeファイルで指定
AWSにprod.composeをおき、ビルド
（アセット関連がなかったため、次からイメージビルド時に、clobberとprecompileを実行するようにする必要がある）