### PR TITLE
config/initializer/session_store.rbの内容を記載、user_sessions_controller#c…

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,8 +1,8 @@
 class UserSessionsController < ApplicationController
   def create
-      uuid = cookies.encrypted[:user_uuid]
-      @user = User.find_by(user_uuid: uuid) if uuid.present?
-      # if uuid.present? && (@user = User.find_by(user_uuid: uuid))と同じ
+      user_id = session[:user_id] # 読み取りだけ
+      @user = User.find_by(id: user_id) if user_id.present?
+      # if user_id.present? && (@user = User.find_by(id: user_id))と同じ
 
       if @user
         session[:user_id] = @user.id

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+Rails.application.config.session_store :cookie_store,
+  key: "_koetomo_session",
+  expire_after: 1.year,
+  httponly: true,                # JS から読ませない
+  secure: Rails.env.production?, # HTTPS のときだけ送る
+  same_site: :strict             # 他サイト経由でのリクエスト受け取らない


### PR DESCRIPTION
・config/initializer/session_store.rbを作成、記載した
・user_sessions_controllerのcreateアクションで、アプリ内でのログイン状態保持のためのセッションと、ユーザー認証のための自前クッキーを設計していたがセッションで統一した。有効期限を１年にして、これを認証とログイン状態保持の２つの役割を持たせる方針で設計した。