### PR TITLE
fix: NGワードの精度修正

### DIFF
--- a/app/channels/rtc_channel.rb
+++ b/app/channels/rtc_channel.rb
@@ -47,7 +47,7 @@ class RtcChannel < ApplicationCable::Channel
       normalized = NgWord.word_filter(transcript)
       Rails.logger.info("[rtc:ng] detected from_user_id=#{current_user.id} room_id=#{@room_id} normalized='#{normalized}'")
       if normalized.present?
-        validation_room = Room.new(speaking: normalized)
+        validation_room = Room.new(speaking: transcript)
         validation_room.validate
 
         if validation_room.errors.added?(:speaking, :ng_word)

--- a/app/models/ng_word.rb
+++ b/app/models/ng_word.rb
@@ -1,14 +1,35 @@
 class NgWord < ApplicationRecord
+  DISCLOSURE_CONTEXT_WINDOW = 12
+  AFFIRMATIVE_DISCLOSURE_PATTERNS = [
+    /教え(?:て(?:ください)?|てくれ|ろ|なさい|てよ)/,
+    /言(?:って(?:ください)?|ってくれ|え|いなさい)/,
+    /伝え(?:て(?:ください)?|てくれ|ろ|なさい)/,
+    /送(?:って(?:ください)?|ってくれ|れ|りなさい)/,
+    /見せ(?:て(?:ください)?|てくれ|ろ|なさい)/,
+    /書(?:いて(?:ください)?|いてくれ|け|きなさい)/,
+    /入力(?:して(?:ください)?|してくれ|しろ|しなさい)/
+  ].freeze
+  NEGATIVE_DISCLOSURE_PATTERNS = [
+    /教え(?:ない(?:[でて](?:ください|下さい)?)?|ません|るな|てはいけません|てはだめ|ちゃだめ|なくていい)/,
+    /言(?:わない(?:[でて](?:ください|下さい)?)?|いません|うな|ってはいけません|ってはだめ|わなくていい)/,
+    /伝え(?:ない(?:[でて](?:ください|下さい)?)?|ません|るな|てはいけません|てはだめ|なくていい)/,
+    /送(?:らない(?:[でて](?:ください|下さい)?)?|りません|るな|ってはいけません|ってはだめ|らなくていい)/,
+    /見せ(?:ない(?:[でて](?:ください|下さい)?)?|ません|るな|てはいけません|てはだめ|なくていい)/,
+    /書(?:かない(?:[でて](?:ください|下さい)?)?|きません|くな|いてはいけません|いてはだめ|かなくていい)/,
+    /入力(?:しない(?:[でて](?:ください|下さい)?)?|しません|するな|してはいけません|してはだめ|しなくていい)/
+  ].freeze
+
   before_validation :normalize_word
 
-  validates :word, presence: true, uniqueness: true
-  validates :word, format: { with: /\A[a-zぁ-ん]+\z/ }
+  validates :word, presence: true, uniqueness: true # before_validationで正規化されたself.wordが:wordに該当する
+  validates :word, format: { with: /\A[a-zぁ-ん\p{Han}]+\z/ }
+
   # このネスト内のメソッド全てをクラスメソッドとして扱うよってこと。self.⚪︎⚪︎って書かなくてOK
   class << self
     def word_filter(text)
       return "" if text.blank?
 
-      s = text.to_s.dup
+      s = text.to_s.dup # dupメソッドで、元々のNgWordインスタンスの複製を作る。(非破壊)
 
       # 1) Unicode正規化（全角英数→半角など）
       s = s.unicode_normalize(:nfkc)
@@ -22,7 +43,7 @@ class NgWord < ApplicationRecord
       # 4) 記号・数字・空白をすべて削除
       s = s.gsub(/\d+/, "")             # 数字を削除
       s = s.gsub(/\s+/, "")             # 空白類を削除
-      s = s.gsub(/[^a-zぁ-ん]+/, "")    # 上記以外の記号などを削除
+      s = s.gsub(/[^a-zぁ-ん\p{Han}]+/, "") # 漢字は残しつつ、記号などを削除
 
       # 5) 英字の同じ文字連続を1文字に潰す
       s = s.gsub(/([a-z])\1+/, '\1')
@@ -32,11 +53,59 @@ class NgWord < ApplicationRecord
       filtered_word = word_filter(text)
       return false if filtered_word.blank?
 
-      NgWord.pluck(:word).any? do |db_word|
-        filtered_db_word = word_filter(db_word)
-        next false if filtered_db_word.blank?
-        filtered_word.include?(filtered_db_word)
+      matched_ng_words(filtered_word).any?
+    end
+
+    def conversation_ng?(text)
+      filtered_word = word_filter(text)
+      return false if filtered_word.blank?
+
+      matched_ng_words(filtered_word).any? do |matched_word|
+        disclosure_request_for?(filtered_word, matched_word)
       end
+    end
+
+    private
+
+    def matched_ng_words(filtered_word)
+      NgWord.pluck(:word).filter_map do |db_word| # filter_mapメソッドはmapと違い、nilやfalseを中身に含めない
+        next if db_word.blank? # blankあればtrueで次の配列の中身を査定
+        db_word if filtered_word.include?(db_word)
+      end
+    end
+
+    def disclosure_request_for?(filtered_word, matched_word)
+      occurrence_segments(filtered_word, matched_word).any? do |segment|
+        next false if negative_disclosure?(segment)
+        affirmative_disclosure?(segment) || direct_disclosure_request?(segment, matched_word)
+      end
+    end
+
+    def occurrence_segments(filtered_word, matched_word)
+      segments = []
+      start_at = 0
+
+      while (index = filtered_word.index(matched_word, start_at))
+        from = [ index - DISCLOSURE_CONTEXT_WINDOW, 0 ].max
+        to = [ index + matched_word.length + DISCLOSURE_CONTEXT_WINDOW, filtered_word.length ].min
+        segments << filtered_word[from...to]
+        start_at = index + matched_word.length
+      end
+
+      segments
+    end
+
+    def negative_disclosure?(segment)
+      NEGATIVE_DISCLOSURE_PATTERNS.any? { |pattern| pattern.match?(segment) }
+    end
+
+    def affirmative_disclosure?(segment)
+      AFFIRMATIVE_DISCLOSURE_PATTERNS.any? { |pattern| pattern.match?(segment) }
+    end
+
+    def direct_disclosure_request?(segment, matched_word)
+      escaped_word = Regexp.escape(matched_word)
+      /(?:#{escaped_word})(?:を|は|も)?(?:ください|下さい|ちょうだい|頂戴|くれ)/.match?(segment)
     end
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -16,5 +16,5 @@ class Room < ApplicationRecord
           source: :user
   # ng_word: trueは、カスタムバリデータを呼ぶための記法
   validates :topic, length: { maximum: 12 }, presence: true, ng_word: true
-  validates :speaking, ng_word: true
+  validates :speaking, ng_word: { contextual: true }
 end

--- a/app/validators/ng_word_validator.rb
+++ b/app/validators/ng_word_validator.rb
@@ -1,11 +1,13 @@
 class NgWordValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-      return if value.blank?
+    return if value.blank?
 
-      if NgWord.ng?(value) # .ngは、valueがNgWordと一致するかを真偽値で返すクラスメソッド
-        record.errors.add(
-          attribute, :ng_word
-        )
-      end
+    checker = options[:contextual] ? :conversation_ng? : :ng?
+
+    if NgWord.public_send(checker, value) # 会話文だけは文脈込みで判定
+      record.errors.add(
+        attribute, :ng_word
+      )
+    end
   end
 end

--- a/spec/models/ng_word_spec.rb
+++ b/spec/models/ng_word_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe NgWord, type: :model do
       text = "ＡＡＡ!! カタカナー １２３"
       expect(described_class.word_filter(text)).to eq("aかたかな")
     end
+
+    it "keeps kanji while removing symbols and spaces" do
+      text = "口座番号 を!! 教えて"
+      expect(described_class.word_filter(text)).to eq("口座番号を教えて")
+    end
   end
 
   describe ".ng?" do
@@ -29,6 +34,34 @@ RSpec.describe NgWord, type: :model do
       allow(described_class).to receive(:pluck).with(:word).and_return([ "だめ" ])
 
       expect(described_class.ng?("こんにちは")).to be(false)
+    end
+
+    it "matches kanji ng words too" do
+      allow(described_class).to receive(:pluck).with(:word).and_return([ "口座番号" ])
+
+      expect(described_class.ng?("口座番号について話そう")).to be(true)
+    end
+  end
+
+  describe ".conversation_ng?" do
+    before do
+      allow(described_class).to receive(:pluck).with(:word).and_return([ "口座番号" ])
+    end
+
+    it "returns true when asking to disclose an ng word" do
+      expect(described_class.conversation_ng?("口座番号を教えてください")).to be(true)
+    end
+
+    it "returns true when commanding to disclose an ng word" do
+      expect(described_class.conversation_ng?("口座番号を教えろ")).to be(true)
+    end
+
+    it "returns false when the request is negated" do
+      expect(described_class.conversation_ng?("口座番号を教えないてください")).to be(false)
+    end
+
+    it "returns false when the ng word is mentioned without a request context" do
+      expect(described_class.conversation_ng?("口座番号の管理は大事だね")).to be(false)
     end
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Room, type: :model do
   describe "validations" do
     it "is valid with normal topic and speaking" do
       allow(NgWord).to receive(:ng?).and_return(false)
+      allow(NgWord).to receive(:conversation_ng?).and_return(false)
 
       room = described_class.new(topic: "雑談しよう", speaking: "こんにちは")
       expect(room).to be_valid
@@ -11,6 +12,7 @@ RSpec.describe Room, type: :model do
 
     it "is invalid when topic is blank" do
       allow(NgWord).to receive(:ng?).and_return(false)
+      allow(NgWord).to receive(:conversation_ng?).and_return(false)
 
       room = described_class.new(topic: "", speaking: "")
       expect(room).to be_invalid
@@ -19,6 +21,7 @@ RSpec.describe Room, type: :model do
 
     it "is invalid when topic is longer than 12 chars" do
       allow(NgWord).to receive(:ng?).and_return(false)
+      allow(NgWord).to receive(:conversation_ng?).and_return(false)
 
       room = described_class.new(topic: "あいうえおかきくけこさしす")
       expect(room).to be_invalid
@@ -34,7 +37,8 @@ RSpec.describe Room, type: :model do
     end
 
     it "adds ng_word error on speaking when speaking includes ng word" do
-      allow(NgWord).to receive(:ng?) { |value| value == "危険" }
+      allow(NgWord).to receive(:ng?).and_return(false)
+      allow(NgWord).to receive(:conversation_ng?) { |value| value == "危険" }
 
       room = described_class.new(topic: "正常", speaking: "危険")
       expect(room).to be_invalid

--- a/spec/validators/ng_word_validator_spec.rb
+++ b/spec/validators/ng_word_validator_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe NgWordValidator, type: :model do
       attr_accessor :text
       validates :text, ng_word: true
     end)
+
+    stub_const("DummyContextualNgRecord", Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :text
+      validates :text, ng_word: { contextual: true }
+    end)
   end
 
   it "adds ng_word error when NgWord.ng? returns true" do
@@ -29,5 +37,13 @@ RSpec.describe NgWordValidator, type: :model do
 
     record = DummyNgRecord.new(text: "セーフ")
     expect(record).to be_valid
+  end
+
+  it "uses contextual judgment when requested" do
+    allow(NgWord).to receive(:conversation_ng?).with("口座番号を教えてください").and_return(true)
+
+    record = DummyContextualNgRecord.new(text: "口座番号を教えてください")
+    expect(record).to be_invalid
+    expect(record.errors.added?(:text, :ng_word)).to be(true)
   end
 end


### PR DESCRIPTION
・NGワード判定の精度修正
　例：口座番号教えて→NG判定、口座番号は教えないでください→NGでない
　
・変更箇所
　rtc_channelからtranscriptをそのままバリデーションにかけて、DBのNGワードにモデルロジックで記載した文脈を加えて判定させるように変更。
　話題の部分は、従来通りDBのワードと一致することで判定させる。