### PR TITLE
update: 文字起こしロジックの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,5 @@ NG ワード検知・注意喚起
 
 ## 画面遷移図
 
-[https://www.figma.com/design/3i7eU7Nla26IkW4hCed57u/%E3%82%A2%E3%83%97%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E7%94%BB%E9%9D%A2?node-id=37-54&p=f&t=s5gPAgQKy4ryVrW9-0](https://www.figma.com/design/3i7eU7Nla26IkW4hCed57u/%E3%82%A2%E3%83%97%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E7%94%BB%E9%9D%A2?node-id=37-54&p=f&t=s5gPAgQKy4ryVrW9-0)
+[https://github.com/taka-thor/myapp/blob/master/docs/screen_transition.md](https://github.com/taka-thor/myapp/blob/master/docs/screen_transition.md)
+

--- a/app/models/ng_word.rb
+++ b/app/models/ng_word.rb
@@ -1,5 +1,5 @@
 class NgWord < ApplicationRecord
-  DISCLOSURE_CONTEXT_WINDOW = 12
+  CLAUSE_SPLITTER = /(?<=。)|(?<=！)|(?<=？)|(?<=\n)|(?<=が)|(?<=けど)|(?<=けれど)/.freeze
   AFFIRMATIVE_DISCLOSURE_PATTERNS = [
     /教え(?:て(?:ください)?|てくれ|ろ|なさい|てよ)/,
     /言(?:って(?:ください)?|ってくれ|え|いなさい)/,
@@ -57,15 +57,28 @@ class NgWord < ApplicationRecord
     end
 
     def conversation_ng?(text)
-      filtered_word = word_filter(text)
-      return false if filtered_word.blank?
+      return false if text.blank?
 
-      matched_ng_words(filtered_word).any? do |matched_word|
-        disclosure_request_for?(filtered_word, matched_word)
+      ng_db_words = NgWord.pluck(:word).reject(&:blank?)
+      return false if ng_db_words.empty?
+
+      # 節ごとに分割して検査することで、NGワードと開示要求が同一節内にある場合のみ検知する
+      split_into_clauses(text).any? do |clause|
+        filtered = word_filter(clause)
+        next false if filtered.blank?
+
+        matched = ng_db_words.select { |w| filtered.include?(w) }
+        next false if matched.empty?
+
+        matched.any? { |w| disclosure_request_for?(filtered, w) }
       end
     end
 
     private
+
+    def split_into_clauses(text)
+      text.split(CLAUSE_SPLITTER).map(&:strip).reject(&:blank?)
+    end
 
     def matched_ng_words(filtered_word)
       NgWord.pluck(:word).filter_map do |db_word| # filter_mapメソッドはmapと違い、nilやfalseを中身に含めない
@@ -74,25 +87,9 @@ class NgWord < ApplicationRecord
       end
     end
 
-    def disclosure_request_for?(filtered_word, matched_word)
-      occurrence_segments(filtered_word, matched_word).any? do |segment|
-        next false if negative_disclosure?(segment)
-        affirmative_disclosure?(segment) || direct_disclosure_request?(segment, matched_word)
-      end
-    end
-
-    def occurrence_segments(filtered_word, matched_word)
-      segments = []
-      start_at = 0
-
-      while (index = filtered_word.index(matched_word, start_at))
-        from = [ index - DISCLOSURE_CONTEXT_WINDOW, 0 ].max
-        to = [ index + matched_word.length + DISCLOSURE_CONTEXT_WINDOW, filtered_word.length ].min
-        segments << filtered_word[from...to]
-        start_at = index + matched_word.length
-      end
-
-      segments
+    def disclosure_request_for?(filtered_clause, matched_word)
+      return false if negative_disclosure?(filtered_clause)
+      affirmative_disclosure?(filtered_clause) || direct_disclosure_request?(filtered_clause, matched_word)
     end
 
     def negative_disclosure?(segment)

--- a/docs/screen_transition.md
+++ b/docs/screen_transition.md
@@ -1,0 +1,38 @@
+# 声友 画面遷移図
+
+```mermaid
+flowchart TD
+    TOP["🏠 トップ\n/"]
+    SESSION{"既存ユーザー？\nセッション確認"}
+    NICKNAME["📝 ニックネーム入力\n/user_nicknames/new"]
+    ICON["🖼️ アイコン選択\n/user_icons/new"]
+    HOME["🏡 ホーム\n/static_pages/home"]
+    ROOMS["📋 部屋一覧\n/rooms"]
+    ROOM_SHOW["🚪 部屋詳細\n/rooms/:id"]
+    RTC["🎙️ 通話画面\n/rtcs/:id"]
+    USER_EDIT["👤 ユーザー情報編集\n/user/edit"]
+    HOW_TO["📖 使い方\n/how_to_talk"]
+    CONTACT["✉️ お問い合わせ\n/contact"]
+    TERMS["📄 利用規約\n/terms"]
+    PRIVACY["🔒 プライバシーポリシー\n/privacy_policy"]
+
+    TOP -->|"「始める」ボタン"| SESSION
+    SESSION -->|"あり（既存ユーザー）"| HOME
+    SESSION -->|"なし（新規ユーザー）"| NICKNAME
+    NICKNAME -->|"バリデーションOK"| ICON
+    NICKNAME -->|"バリデーションNG"| NICKNAME
+    ICON -->|"保存成功"| HOME
+    ICON -->|"保存失敗"| TOP
+
+    HOME -->|"通話部屋を探す"| ROOMS
+    HOME --> USER_EDIT
+    HOME --> HOW_TO
+    HOME --> CONTACT
+    HOME --> TERMS
+    HOME --> PRIVACY
+
+    ROOMS -->|"部屋を選択"| ROOM_SHOW
+    ROOM_SHOW -->|"通話に参加"| RTC
+    RTC -->|"退出"| ROOMS
+    ROOMS -->|"戻る"| HOME
+```


### PR DESCRIPTION
・文字起こしロジックを変更
　旧：transcript内のDBにあるNGワード前後１２文字を判定し文脈判定に使っていた
　　　デメリットとして、会話の長さによっては漏れが生じる
　新：１２文字制限を削除して、transcriptを句読点で区切り検知をするようにした